### PR TITLE
fix hardcoded button text

### DIFF
--- a/src/components/ListTable.vue
+++ b/src/components/ListTable.vue
@@ -113,7 +113,7 @@
           <option v-for="action in bulkActions" :value="action.key">{{ action.label }}</option>
         </select>
 
-        <button class="button action" @click.prevent="handleBulkAction" :disabled="!checkedItems.length">Apply</button>
+        <button class="button action" @click.prevent="handleBulkAction" :disabled="!checkedItems.length">{{ text.apply }}</button>
       </div>
 
       <div class="tablenav-pages">


### PR DESCRIPTION
Hi @tareq1988, first of all, many thanks for this really nice, flexible component and also your vue wp plugin starter, they have both helped me a lot in developing wp plugins! Really good stuff :+1: 
I only found this little issue here where one of the button texts is hardcoded which gets a bit in the way when using this in a non-English context, would be awesome if this fix could be merged and published. Once again, many thanks!